### PR TITLE
feat: 댓글 작성, 조회, 수정, 삭제 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,10 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	//AWS S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 jar {

--- a/src/main/java/com/example/demo/config/SecurityConfig.java
+++ b/src/main/java/com/example/demo/config/SecurityConfig.java
@@ -37,7 +37,6 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/swagger-resources/**",
             "/swagger-ui/**",
-            "/diary/view/**"
     };
 
     @Bean
@@ -51,7 +50,6 @@ public class SecurityConfig {
         http.authorizeHttpRequests(authorize ->
                 authorize
                         .requestMatchers(whiteList).permitAll()
-                        .requestMatchers(HttpMethod.GET, "/diary/likes/{diaryId}").permitAll()
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/example/demo/controller/diary/CommentController.java
+++ b/src/main/java/com/example/demo/controller/diary/CommentController.java
@@ -1,0 +1,69 @@
+package com.example.demo.controller.diary;
+
+import com.example.demo.dto.diary.request.CommentRequest;
+import com.example.demo.dto.diary.response.CommentResponse;
+import com.example.demo.infrastructure.jwt.JwtUtil;
+import com.example.demo.service.diary.CommentService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/diary")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/comment/{diaryId}")
+    public ResponseEntity<String> postLike(HttpServletRequest request, @RequestBody CommentRequest commentRequest,
+                                           @PathVariable(name = "diaryId") long diaryId) {
+        try {
+            String accessToken = jwtUtil.getAccessTokenFromHeader(request);
+            return commentService.createComment(accessToken, commentRequest, diaryId);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @PatchMapping("/comment/{commentId}")
+    public ResponseEntity<String> updateComment(HttpServletRequest request, @RequestBody CommentRequest commentRequest,
+                                                @PathVariable(name = "commentId") long commentId) {
+        try {
+            String accessToken = jwtUtil.getAccessTokenFromHeader(request);
+            return commentService.modifyComment(accessToken, commentRequest, commentId);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @DeleteMapping("/comment/{commentId}")
+    public ResponseEntity<String> deleteComment(HttpServletRequest request, @PathVariable(name = "commentId") long commentId) {
+        try {
+            String accessToken = jwtUtil.getAccessTokenFromHeader(request);
+            return commentService.deleteComment(accessToken, commentId);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @GetMapping("/comment/{diaryId}")
+    public ResponseEntity<List<CommentResponse>> getComments(HttpServletRequest request, @PathVariable(name = "diaryId") long diaryId) {
+        try {
+            return commentService.getComments(diaryId);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+}

--- a/src/main/java/com/example/demo/controller/diary/ViewController.java
+++ b/src/main/java/com/example/demo/controller/diary/ViewController.java
@@ -19,9 +19,10 @@ public class ViewController {
     private final JwtUtil jwtUtil;
 
     @PostMapping("/view/{diaryId}")
-    public ResponseEntity<String> view(@PathVariable(name = "diaryId") long diaryId) {
+    public ResponseEntity<String> view(HttpServletRequest request, @PathVariable(name = "diaryId") long diaryId) {
         try {
-            return viewService.view(diaryId);
+            String accessToken = jwtUtil.getAccessTokenFromHeader(request);
+            return viewService.view(accessToken, diaryId);
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();

--- a/src/main/java/com/example/demo/controller/statistics/StatisticsController.java
+++ b/src/main/java/com/example/demo/controller/statistics/StatisticsController.java
@@ -1,0 +1,31 @@
+package com.example.demo.controller.statistics;
+
+import com.example.demo.dto.statistics.CountDiariesRequest;
+import com.example.demo.infrastructure.jwt.JwtUtil;
+import com.example.demo.service.statistics.StatisticsService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/statistics")
+public class StatisticsController {
+
+    private final StatisticsService service;
+    private final JwtUtil jwtUtil;
+
+    @PostMapping("/diary-count")
+    public ResponseEntity<Long> postLike(HttpServletRequest request, @RequestBody CountDiariesRequest countRequest) {
+        try {
+            String accessToken = jwtUtil.getAccessTokenFromHeader(request);
+            return service.countDiaries(accessToken, countRequest);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/diary/Comment.java
+++ b/src/main/java/com/example/demo/domain/diary/Comment.java
@@ -1,0 +1,42 @@
+package com.example.demo.domain.diary;
+
+import com.example.demo.domain.Account;
+import com.example.demo.dto.diary.request.CommentRequest;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long commentId;
+
+    private String content;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Diary diary;
+
+    public void updateComment(CommentRequest request) {
+        this.content = request.getContent();
+    }
+
+}

--- a/src/main/java/com/example/demo/domain/diary/Diary.java
+++ b/src/main/java/com/example/demo/domain/diary/Diary.java
@@ -34,6 +34,8 @@ public class Diary {
 
     private Boolean commentEnabled;
 
+    private Boolean isPublic;
+
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;

--- a/src/main/java/com/example/demo/domain/diary/View.java
+++ b/src/main/java/com/example/demo/domain/diary/View.java
@@ -20,6 +20,9 @@ public class View {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    private Account account;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     private Diary diary;
 
 }

--- a/src/main/java/com/example/demo/dto/diary/request/CommentRequest.java
+++ b/src/main/java/com/example/demo/dto/diary/request/CommentRequest.java
@@ -1,0 +1,16 @@
+package com.example.demo.dto.diary.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CommentRequest {
+
+    private String content;
+
+}

--- a/src/main/java/com/example/demo/dto/diary/request/DiaryCreationReq.java
+++ b/src/main/java/com/example/demo/dto/diary/request/DiaryCreationReq.java
@@ -1,9 +1,16 @@
 package com.example.demo.dto.diary.request;
 
 import com.example.demo.domain.diary.Emotion;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.stereotype.Service;
 
-@Data
+@Getter
+@Setter
+@ToString
 public class DiaryCreationReq {
 
     private String title;
@@ -11,6 +18,8 @@ public class DiaryCreationReq {
     private String content;
 
     private Boolean commentEnabled;
+
+    private Boolean isPublic;
 
     private Double longitude;
 

--- a/src/main/java/com/example/demo/dto/diary/request/DiaryModificationReq.java
+++ b/src/main/java/com/example/demo/dto/diary/request/DiaryModificationReq.java
@@ -15,6 +15,8 @@ public class DiaryModificationReq {
 
     private Boolean commentEnabled;
 
+    private Boolean isPublic;
+
     private Point geography;
 
     private Emotion emotion;

--- a/src/main/java/com/example/demo/dto/diary/response/CommentResponse.java
+++ b/src/main/java/com/example/demo/dto/diary/response/CommentResponse.java
@@ -1,0 +1,21 @@
+package com.example.demo.dto.diary.response;
+
+import com.example.demo.domain.diary.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class CommentResponse {
+
+    private long commentId;
+
+    private String content;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/example/demo/dto/statistics/CountDiariesRequest.java
+++ b/src/main/java/com/example/demo/dto/statistics/CountDiariesRequest.java
@@ -1,0 +1,12 @@
+package com.example.demo.dto.statistics;
+
+import lombok.Data;
+
+@Data
+public class CountDiariesRequest {
+
+    private int year;
+
+    private int month;
+
+}

--- a/src/main/java/com/example/demo/repository/diary/CommentRepository.java
+++ b/src/main/java/com/example/demo/repository/diary/CommentRepository.java
@@ -1,0 +1,14 @@
+package com.example.demo.repository.diary;
+
+import com.example.demo.domain.diary.Comment;;
+import com.example.demo.domain.diary.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByDiary(Diary diary);
+}

--- a/src/main/java/com/example/demo/repository/diary/DiaryRepository.java
+++ b/src/main/java/com/example/demo/repository/diary/DiaryRepository.java
@@ -1,9 +1,15 @@
 package com.example.demo.repository.diary;
 
+import com.example.demo.domain.Account;
 import com.example.demo.domain.diary.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    List<Diary> findByAccountAndCreatedAtBetween(Account account, LocalDateTime startDate, LocalDateTime endDate);
+
 }

--- a/src/main/java/com/example/demo/service/diary/CommentService.java
+++ b/src/main/java/com/example/demo/service/diary/CommentService.java
@@ -1,0 +1,114 @@
+package com.example.demo.service.diary;
+
+import com.example.demo.domain.Account;
+import com.example.demo.domain.diary.Comment;
+import com.example.demo.domain.diary.Diary;
+import com.example.demo.dto.diary.request.CommentRequest;
+import com.example.demo.dto.diary.response.CommentResponse;
+import com.example.demo.infrastructure.jwt.JwtUtil;
+import com.example.demo.repository.AccountRepository;
+import com.example.demo.repository.diary.CommentRepository;
+import com.example.demo.repository.diary.DiaryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final JwtUtil jwtUtil;
+
+    private final AccountRepository accountRepository;
+
+    private final DiaryRepository diaryRepository;
+
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public ResponseEntity<String> createComment(String accessToken, CommentRequest request, long diaryId) {
+
+        long userId = jwtUtil.getUserPk(accessToken);
+
+        Account account = accountRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Not found User"));
+
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new RuntimeException("Not found Diary"));
+
+        Comment comment = Comment.builder()
+                .content(request.getContent())
+                .account(account)
+                .diary(diary)
+                .build();
+
+        commentRepository.save(comment);
+
+        return ResponseEntity.ok("Success create Comment");
+
+    }
+
+    @Transactional
+    public ResponseEntity<String> modifyComment(String accessToken, CommentRequest request, long commentId) {
+
+        long userId = jwtUtil.getUserPk(accessToken);
+
+        Account account = accountRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Not found User"));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("Not found Comment"));
+
+        if (account.getId() != comment.getAccount().getId()) {
+            throw new RuntimeException("You can only modify comment authored by yourself.");
+        } else {
+            comment.setUpdatedAt(LocalDateTime.now());
+            comment.updateComment(request);
+        }
+        commentRepository.save(comment);
+
+        return ResponseEntity.ok("Success modify Comment");
+    }
+
+    @Transactional
+    public ResponseEntity<String> deleteComment(String accessToken, long commentId) {
+
+        long userId = jwtUtil.getUserPk(accessToken);
+
+        Account account = accountRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Not found User"));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("Not found Comment"));
+
+        if(account.getId() != comment.getAccount().getId()) {
+            throw new RuntimeException("You can only delete diary authored by yourself.");
+        } else {
+            commentRepository.deleteById(commentId);
+        }
+
+        return ResponseEntity.ok("Success delete Comment");
+
+    }
+
+    public ResponseEntity<List<CommentResponse>> getComments(long diaryId) {
+
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new RuntimeException("Not found Diary"));
+
+        List<Comment> comments = commentRepository.findAllByDiary(diary);
+
+        List<CommentResponse> commentResponses = comments.stream()
+                .map(comment -> new CommentResponse(comment.getCommentId(), comment.getContent(), comment.getCreatedAt(), comment.getUpdatedAt()))
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(commentResponses);
+
+    }
+
+}

--- a/src/main/java/com/example/demo/service/diary/DiaryService.java
+++ b/src/main/java/com/example/demo/service/diary/DiaryService.java
@@ -47,6 +47,7 @@ public class DiaryService {
                 .title(request.getTitle())
                 .content(request.getContent())
                 .commentEnabled(request.getCommentEnabled())
+                .isPublic(request.getIsPublic())
                 .geography(location)
                 .emotion(request.getEmotion())
                 .createdAt(LocalDateTime.now())
@@ -89,6 +90,9 @@ public class DiaryService {
             }
             if (request.getCommentEnabled() != null) {
                 diary.setCommentEnabled(request.getCommentEnabled());
+            }
+            if(request.getIsPublic() != null) {
+                diary.setIsPublic(request.getIsPublic());
             }
             if(request.getEmotion() != null) {
                 diary.setEmotion(request.getEmotion());

--- a/src/main/java/com/example/demo/service/diary/ViewService.java
+++ b/src/main/java/com/example/demo/service/diary/ViewService.java
@@ -25,12 +25,18 @@ public class ViewService {
     private final JwtUtil jwtUtil;
 
     @Transactional
-    public ResponseEntity<String> view(long diaryId) {
+    public ResponseEntity<String> view(String accessToken, long diaryId) {
 
         Diary diary = diaryRepository.findById(diaryId)
                 .orElseThrow(() -> new RuntimeException("Not found Diary"));
 
+        long userId = jwtUtil.getUserPk(accessToken);
+
+        Account account = accountRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Not found User"));
+
        View view = View.builder()
+               .account(account)
                .diary(diary)
                .build();
 

--- a/src/main/java/com/example/demo/service/statistics/StatisticsService.java
+++ b/src/main/java/com/example/demo/service/statistics/StatisticsService.java
@@ -1,0 +1,42 @@
+package com.example.demo.service.statistics;
+
+import com.example.demo.domain.Account;
+import com.example.demo.domain.diary.Diary;
+import com.example.demo.dto.statistics.CountDiariesRequest;
+import com.example.demo.infrastructure.jwt.JwtUtil;
+import com.example.demo.repository.AccountRepository;
+import com.example.demo.repository.diary.DiaryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+
+    private final DiaryRepository diaryRepository;
+    private final AccountRepository accountRepository;
+    private final JwtUtil jwtUtil;
+
+    public ResponseEntity<Long> countDiaries(String accessToken, CountDiariesRequest request) {
+
+        long userId = jwtUtil.getUserPk(accessToken);
+
+        Account account = accountRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Not found User"));
+
+        LocalDateTime startDate = LocalDateTime.of(request.getYear(), request.getMonth(), 1, 0, 0, 0); // 해당 월의 첫 번째 날의 자정(00:00:00)
+        LocalDateTime endDate = startDate.withDayOfMonth(startDate.toLocalDate().lengthOfMonth()).withHour(23).withMinute(59).withSecond(59); // 해당 월의 마지막 날의 23:59:59
+
+        List<Diary> diaries = diaryRepository.findByAccountAndCreatedAtBetween(account, startDate, endDate);
+        long count = diaries.size();
+
+        return ResponseEntity.ok(count);
+
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,7 +9,8 @@ spring.datasource.password=password
 #JPA
 spring.jpa.hibernate.ddl-auto = create
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.show-sql=true 
+spring.jpa.show-sql=true ls
+
 
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE


### PR DESCRIPTION
[작업 사항]
- 댓글 작성, 조회, 수정, 삭제 api추가
- 한 달 간 작성한 일기 개수에 대한 통계 관련 api 추가
- diary에 isPublic 필드 추가
- 일기 작성, 수정시 dto 매핑 관련 코드 수정
- view에 account 연결