### PR TITLE
[#12/feature] 더미 데이터 생성 코드 추가

### DIFF
--- a/src/main/java/com/example/demo/domain/diary/Diary.java
+++ b/src/main/java/com/example/demo/domain/diary/Diary.java
@@ -40,11 +40,12 @@ public class Diary {
 
     private LocalDateTime updatedAt;
 
-    private Point geograpy;
+    private Point geography;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Emotion emotion;
+
 
     public void updateDiary(String title, String content, Boolean commentEnabled, Emotion emotion) {
         this.title = title;

--- a/src/main/java/com/example/demo/dto/diary/response/DiaryListResponse.java
+++ b/src/main/java/com/example/demo/dto/diary/response/DiaryListResponse.java
@@ -37,8 +37,8 @@ public class DiaryListResponse {
                 entry.isCurrentUserDiary = true;
             }
 
-            Point geograpy = diary.getGeograpy();
-            entry.longitude = geograpy.getY();
+            Point geograpy = diary.getGeography();
+            entry.longitude = geograpy.getX();
             entry.latitude = geograpy.getY();
 
             entry.emotion = diary.getEmotion();

--- a/src/main/java/com/example/demo/dto/diary/response/DiaryReadResponse.java
+++ b/src/main/java/com/example/demo/dto/diary/response/DiaryReadResponse.java
@@ -59,8 +59,8 @@ public class DiaryReadResponse {
                 .commentEnabled(diary.getCommentEnabled())
                 .createdAt(diary.getCreatedAt())
                 .updatedAt(diary.getUpdatedAt())
-                .longitude(diary.getGeograpy().getX())
-                .latitude(diary.getGeograpy().getY())
+                .longitude(diary.getGeography().getX())
+                .latitude(diary.getGeography().getY())
                 .emotion(diary.getEmotion())
                 .isCurrentUserDiary(isCurrentUserDiary)
                 .build();

--- a/src/main/java/com/example/demo/dto/statistics/StatisticsResponse.java
+++ b/src/main/java/com/example/demo/dto/statistics/StatisticsResponse.java
@@ -1,0 +1,36 @@
+package com.example.demo.dto.statistics;
+
+import com.example.demo.domain.diary.Diary;
+import com.example.demo.domain.diary.Emotion;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class StatisticsResponse {
+
+    private long diaryId;
+
+    private Emotion emotion;
+
+    private int likeCount;
+
+    private int viewCount;
+
+    private LocalDate createdAt;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    public StatisticsResponse(Diary diary) {
+        this.diaryId = diary.getDiaryId();
+        this.emotion = diary.getEmotion();
+        this.likeCount = diary.getLikeCount();
+        this.viewCount = diary.getViewCount();
+        this.createdAt = diary.getCreatedAt().toLocalDate();
+        this.longitude = diary.getGeography().getX();
+        this.latitude = diary.getGeography().getY();
+    }
+
+}

--- a/src/main/java/com/example/demo/init/DataInitializer.java
+++ b/src/main/java/com/example/demo/init/DataInitializer.java
@@ -1,0 +1,171 @@
+package com.example.demo.init;
+
+import com.example.demo.config.SecurityConfig;
+import com.example.demo.domain.Account;
+import com.example.demo.domain.diary.Comment;
+import com.example.demo.domain.diary.Diary;
+import com.example.demo.domain.diary.Emotion;
+import com.example.demo.dto.oauth.OAuthProvider;
+import com.example.demo.repository.AccountRepository;
+import com.example.demo.repository.diary.CommentRepository;
+import com.example.demo.repository.diary.DiaryRepository;
+import com.example.demo.service.diary.DiaryService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DataInitializer implements CommandLineRunner {
+
+    private final AccountRepository accountRepository;
+    private final DiaryRepository diaryRepository;
+    private final CommentRepository commentRepository;
+    private final SecurityConfig securityConfig;
+    private final DiaryService diaryService;
+
+    @Override
+    public void run(String... args) throws Exception {
+        initialize();
+
+    }
+
+    public void initialize() {
+        initAccounts();
+        initDiaries();
+        initComments();
+    }
+
+    public void initAccounts() {
+
+        if (!accountRepository.existsByEmail("test1@naver.com")) {
+            Account account1 = Account.createSignUpMember("test1", "test1@naver.com", securityConfig.passwordEncoder().encode("Password123!"), OAuthProvider.SELF);
+            accountRepository.save(account1);
+        }
+
+        if (!accountRepository.existsByEmail("test2@naver.com")) {
+            Account account2 = Account.createSignUpMember("test2", "test2@naver.com", securityConfig.passwordEncoder().encode("Password123!"), OAuthProvider.SELF);
+            accountRepository.save(account2);
+        }
+
+        if (!accountRepository.existsByEmail("test3@naver.com")) {
+            Account account3 = Account.createSignUpMember("test3", "test3@naver.com", securityConfig.passwordEncoder().encode("Password123!"), OAuthProvider.SELF);
+            accountRepository.save(account3);
+        }
+
+        if (!accountRepository.existsByEmail("test4@naver.com")) {
+            Account account4 = Account.createSignUpMember("test4", "test4@naver.com", securityConfig.passwordEncoder().encode("Password123!"), OAuthProvider.KAKAO);
+            accountRepository.save(account4);
+        }
+
+        if (!accountRepository.existsByEmail("test5@naver.com")) {
+            Account account5 = Account.createSignUpMember("test5", "test5@naver.com", securityConfig.passwordEncoder().encode("Password123!"), OAuthProvider.KAKAO);
+            accountRepository.save(account5);
+        }
+
+    }
+
+    public void initDiaries() {
+
+        //가톨릭대학교 니콜스관
+        createDiary("1", "첫 번째 일기", Emotion.JOY, 10, 0, true, true, 1, 126.802311, 37.485985);
+        //가톨릭대학교 마리아관
+        createDiary("2", "두 번째 일기", Emotion.JOY, 20, 5, true, true, 1, 126.802875, 37.486328);
+        //가톨릭대학교 중앙도서관
+        createDiary("3", "세 번째 일기", Emotion.SADNESS, 50, 30, true, true, 1, 126.799911, 37.486836);
+        //가톨릭대학교 운동장
+        createDiary("4", "네 번째 일기", Emotion.ANGER, 20, 17, true, true, 1, 126.800938, 37.487825);
+        //가톨릭대학교 콘서트홀
+        createDiary("5", "다섯 번째 일기", Emotion.DISGUST, 0, 0, false, false, 1, 126.799524, 37.488039);
+        //역곡 크라이 치즈버거 인근
+        createDiary("1", "첫 번째 일기", Emotion.ANXIETY, 10, 0, true, true, 2, 126.806021, 37.485333);
+        //역곡 고등학교
+        createDiary("2", "두 번째 일기", Emotion.ENVY, 20, 5, true, true, 2, 126.809622, 37.491979);
+        //역곡역
+        createDiary("1", "첫 번째 일기", Emotion.SADNESS, 50, 30, true, true, 3, 126.812014, 37.485298);
+        //시청역
+        createDiary("2", "두 번째 일기", Emotion.ENNUI, 0, 0, false , false, 3, 126.977158, 37.565490);
+        //을지로입구역
+        createDiary("1", "첫 번째 일기", Emotion.JOY, 10, 0, true, true, 4, 126.982161, 37.565923);
+        //롯데백화점 본점
+        createDiary("1", "첫 번째 일기", Emotion.ANGER, 10, 0, true, true, 5, 126.981754, 37.564698);
+        //서울역
+        createDiary("2", "두 번째 일기", Emotion.FEAR, 20, 5, true, true, 5, 126.970530, 37.554478);
+        //용산역
+        createDiary("3", "세 번째 일기", Emotion.SADNESS, 50, 30, true, true, 5, 126.964385, 37.529717);
+        //이대역
+        createDiary("4", "네 번째 일기", Emotion.ANGER, 40, 0, false, true, 5, 126.946852, 37.556849);
+        //가톨릭대학교 성신교정
+        createDiary("5", "다섯 번째 일기", Emotion.DISGUST, 0, 0, false, false, 5, 127.004596, 37.586310);
+
+    }
+
+    public void initComments() {
+
+        createComment("힘내요", 1, 6);
+        createComment("부러워요", 1, 7);
+        createComment("즐거워요", 1, 10);
+        createComment("무서워요", 1, 12);
+        createComment("기뻐요", 2, 1);
+        createComment("좋아요", 2, 2);
+        createComment("화나요", 2, 4);
+        createComment("슬퍼요", 2, 8);
+        createComment("화나요", 2, 11);
+        createComment("좋아요", 3, 2);
+        createComment("파이팅", 3, 6);
+        createComment("기뻐요", 3, 10);
+        createComment("슬퍼요", 3, 13);
+        createComment("즐거워요", 4, 1);
+        createComment("할 수 있어요", 4, 6);
+        createComment("부러워요", 5, 1);
+        createComment("즐거워요", 5, 2);
+        createComment("슬퍼요", 5, 3);
+        createComment("힘내요", 5, 4);
+        createComment("힘내세요", 5, 6);
+        createComment("파이팅", 5, 7);
+        createComment("슬퍼요", 5, 8);
+        createComment("좋아요", 5, 10);
+
+    }
+
+    private void createDiary(String title, String content, Emotion emotion, int viewCount, int likeCount, Boolean commentEnabled, Boolean isPublic, long accountId, double longitude, double latitude) {
+
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new RuntimeException("Not found User"));
+
+        Diary diary = new Diary();
+        diary.setTitle(title);
+        diary.setContent(content);
+        diary.setEmotion(emotion);
+        diary.setViewCount(viewCount);
+        diary.setLikeCount(likeCount);
+        diary.setCommentEnabled(commentEnabled);
+        diary.setIsPublic(isPublic);
+        diary.setAccount(account);
+        diary.setGeography(diaryService.setLocation(longitude, latitude));
+
+        diaryRepository.save(diary);
+
+    }
+
+    private void createComment(String content, long accountId, long diaryId) {
+
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new RuntimeException("Not found User"));
+
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new RuntimeException("Not found Diary "));
+
+        Comment comment = new Comment();
+        comment.setContent(content);
+        comment.setAccount(account);
+        comment.setDiary(diary);
+
+        commentRepository.save(comment);
+
+    }
+
+}

--- a/src/main/java/com/example/demo/repository/AccountRepository.java
+++ b/src/main/java/com/example/demo/repository/AccountRepository.java
@@ -48,6 +48,16 @@ public class AccountRepository {
     }
 
 
+    public boolean existsByEmail(String email) {
 
+        String query = "select count(m) from Account m where m.email = :email";
+
+        Long count = em.createQuery(query, Long.class)
+                .setParameter("email", email)
+                .getSingleResult();
+
+        return count > 0;
+
+    }
 
 }

--- a/src/main/java/com/example/demo/repository/diary/DiaryRepository.java
+++ b/src/main/java/com/example/demo/repository/diary/DiaryRepository.java
@@ -18,13 +18,13 @@ public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
     List<Diary> findByAccountAndCreatedAtBetween(Account account, LocalDateTime startDate, LocalDateTime endDate);
 
-    @Query(value = "select t from Diary as t where within(t.geograpy, :boundary) = true order by t.likeCount desc ")
+    @Query(value = "select t from Diary as t where within(t.geography, :boundary) = true order by t.likeCount desc ")
     Page<Diary> getDiaryListOrderByLike(@Param("boundary") Geometry boundary, Pageable pageable);
 
-    @Query(value = "select t from Diary as t where within(t.geograpy, :boundary) = true order by t.viewCount desc")
+    @Query(value = "select t from Diary as t where within(t.geography, :boundary) = true order by t.viewCount desc")
     Page<Diary> getDiaryListOrderByView(@Param("boundary") Geometry boundary, Pageable pageable);
 
-    @Query(value = "select t from Diary as t where within(t.geograpy, :boundary) = true order by t.createdAt desc")
+    @Query(value = "select t from Diary as t where within(t.geography, :boundary) = true order by t.createdAt desc")
     Page<Diary> getDiaryListOrderByCreatedAt(@Param("boundary") Geometry boundary, Pageable pageable);
 
     List<Diary> findAllByAccountOrderByLikeCountDesc(Account account);

--- a/src/main/java/com/example/demo/service/diary/DiaryService.java
+++ b/src/main/java/com/example/demo/service/diary/DiaryService.java
@@ -64,7 +64,7 @@ public class DiaryService {
                 .title(request.getTitle())
                 .content(request.getContent())
                 .commentEnabled(request.getCommentEnabled())
-                .geograpy(location)
+                .geography(location)
                 .isPublic(request.getIsPublic())
                 .emotion(request.getEmotion())
                 .createdAt(LocalDateTime.now())

--- a/src/main/java/com/example/demo/service/statistics/StatisticsService.java
+++ b/src/main/java/com/example/demo/service/statistics/StatisticsService.java
@@ -7,6 +7,7 @@ import com.example.demo.dto.statistics.StatisticsResponse;
 import com.example.demo.infrastructure.jwt.JwtUtil;
 import com.example.demo.repository.AccountRepository;
 import com.example.demo.repository.diary.DiaryRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +23,7 @@ public class StatisticsService {
     private final AccountRepository accountRepository;
     private final JwtUtil jwtUtil;
 
+    @Transactional
     public List<StatisticsResponse> countDiaries(String accessToken, CountDiariesRequest request) {
 
         long userId = jwtUtil.getUserPk(accessToken);
@@ -43,6 +45,7 @@ public class StatisticsService {
 
     }
 
+    @Transactional
     public StatisticsResponse getMostLikedDiary(String accessToken) {
 
         long userId = jwtUtil.getUserPk(accessToken);
@@ -62,6 +65,7 @@ public class StatisticsService {
 
     }
 
+    @Transactional
     public StatisticsResponse getMostViewedDiary(String accessToken) {
 
         long userId = jwtUtil.getUserPk(accessToken);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,7 @@ spring.jpa.hibernate.ddl-auto = create
 spring.jpa.database-platform=org.hibernate.spatial.dialect.mysql.MySQLSpatialDialect
 spring.jpa.show-sql=true
 
+
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 


### PR DESCRIPTION
[ 변경 사항 ]
- geograhpy 필드에 대해 오타 발견하여 관련 코드들 수정
- 누락되었던 StatisticsResponse 클래스 추가
- 더미 데이터 생성 클래스 작성


[ 전달 사항 ] 
- 더미 데이터로 기존 코드 테스트 진행해 보려 했으나, 이전에 말씀드린 jwt exception 관련 에러가 이번에는 정상적으로... 모든 api에서 동작하지 않아 테스트는 진행하지 못함
- 현재 account, diary, comment 관련 더미 데이터가 들어가 있으며 이번 발표에서는 diaryImage, view, like 관련 더미 데이터까지는 필요하지 않을 것 같아 생성해 놓지 않았는데 필요하다면 추가할 예정 
- 지금 diary, comment 더미 데이터를 넣을 때 기존 데이터가 없다는 가정하게 id 값을 넣어 놓았기 때문에 서버 실행 전 모든 테이블들 한 번씩 drop 시키는 것이 좋아보임 (id 값이 아니라 account로 하고 싶었는데 우선 시간이 없어서 id로 진행 추후 디벨롭 생각중)
- 지금 가장 큰 문제가 코드를 실행하면 실행할 때마다 더미 데이터가 쌓이게 됨 account 값 같은 경우는 이메일로 중복 처리를 해놓았으나 diary, comment 같은 경우는 중복 처리가 애매한 상태 그래서 어떻게 처리를 할 건지 논의해 봐야 함
- 진형님께서는 일기 관련 데이터 몇 개만 더 추가해 주시고 authentication 관련해서 수정하기로 하셨던 부분 수정해 주신 다음에 저희가 발표해야 하는 api들만 한 번씩 테스트 해주시면 좋을 것 같습니다 api 테스트 할 시간 없으시면 말씀해 주세욥 파이팅...!
